### PR TITLE
Fixes the logo display

### DIFF
--- a/app/javascript/components/InfoWindowElement.js
+++ b/app/javascript/components/InfoWindowElement.js
@@ -4,7 +4,7 @@ export const InfoWindowElementContent = ({ img, link, description, event_date, l
   return `
     <div id="content">
       <div class="flex">
-        <img src=${img} class="mr-5 w-20 h-fit" />
+        <img src=${img} class="mr-5 w-20 h-20" />
         <div class="w-2/3">
          ${event_date ? `<p>${event_date}</p>` : ""}
          ${location ? `<p class="mb-2">${location}</p>` : ""}


### PR DESCRIPTION
I noticed how stretched (and unusable to the eye) most logos are in the popup window. 

This PR fixes that by setting the height to be the same as the width (aka. a square) which fixes the issue and shows the logos better.